### PR TITLE
TDK-9019 Adding Bug fix in build.sh for Opensourced L1 HALs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ function check_next_revision()
     pushd ./ut-core
     # Set default UT_CORE_PROJECT_VERSION to next revision, if it's set then we don't need to tell you again
     if [ -v ${UT_CORE_PROJECT_VERSION} ]; then
-        UT_CORE_PROJECT_VERSION=$(git tag | grep ${UT_PROJECT_MAJOR_VERSION} | sort -r | head -n1)
+        UT_CORE_PROJECT_VERSION=$(git tag | grep ^${UT_PROJECT_MAJOR_VERSION} | sort -r | head -n1)
         UT_NEXT_VERSION=$(git tag | sort -r | head -n1)
         echo -e ${YELLOW}ut-core version selected:[${UT_CORE_PROJECT_VERSION}]${NC}
         if [ "${UT_NEXT_VERSION}" != "${UT_CORE_PROJECT_VERSION}" ]; then


### PR DESCRIPTION
Reason for change: Adding bug fix in build.sh for L1 LPA HAL Suite
Risks: Low
Test Procedure: Check the ticket